### PR TITLE
Changed let to const variables

### DIFF
--- a/src/consoleWrapper.ts
+++ b/src/consoleWrapper.ts
@@ -1,7 +1,5 @@
-let ConsoleWrapper = {
-    wrap : (text: string, indentation = '') => {
-        return `\n${indentation}console.log("${text} ", ${text});`;
-    }
+const ConsoleWrapper = {
+    wrap : (text: string, indentation = '') => `\n${indentation}console.log("${text} ", ${text});`
 };
 
 export default ConsoleWrapper;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,31 +4,30 @@ import consoleWrapper from './consoleWrapper';
 import {paste, copy} from 'copy-paste';
 
 export function activate(context: vscode.ExtensionContext) {
-    let disposable = vscode.commands.registerCommand("extension.consoleWrapper", () => {
+    const disposable = vscode.commands.registerCommand("extension.consoleWrapper", () => {
         const editor = vscode.window.activeTextEditor;
         if (!editor) {
             return;
         }
 
-        let expandedSelection = undefined;
-        expandedSelection = getSelection(editor);
+        const expandedSelection = getSelection(editor);
         if (expandedSelection) {
-            let text = editor.document.getText(expandedSelection);
+            const text = editor.document.getText(expandedSelection);
             if (text) {
                 editor.edit((currentText) => {
                     currentText.insert(new vscode.Position(expandedSelection.end.line, 100000), consoleWrapper.wrap(text, getLineIndentation(expandedSelection)));
                 });
             }
-        }
-        else
+        } else {
             paste((cb, clipboardContent) => {
                 if (!!clipboardContent) {
-                    let selection = editor.selection;
+                    const selection = editor.selection;
                     editor.edit((currentText) => {
                         currentText.insert(new vscode.Position(selection.active.line, selection.active.character), consoleWrapper.wrap(clipboardContent));
                     });
                 }
             });
+        }
     });
 
     context.subscriptions.push(disposable);
@@ -38,20 +37,18 @@ function getSelection(editor: vscode.TextEditor): vscode.Selection {
     const selection = editor.selection;
     if (selection.isEmpty) {
         const wordRange = editor.document.getWordRangeAtPosition(selection.active);
-        if (!!wordRange) {
-            let expandedSelection = new vscode.Selection(wordRange.start.line, wordRange.start.character, wordRange.end.line, wordRange.end.character);
-            return expandedSelection;
-        }
-        return null;
+        return !!wordRange ?
+                new vscode.Selection(wordRange.start.line, wordRange.start.character,
+                wordRange.end.line, wordRange.end.character) : null
     }
     return selection;
 }
 
 function getLineIndentation(selection: vscode.Selection) {
     const { document, options: { tabSize, insertSpaces } } = vscode.window.activeTextEditor
-    let indentStr = insertSpaces ? new Array((tabSize as number) + 1).join(' ') : '\t'
+    const indentStr = insertSpaces ? new Array((tabSize as number) + 1).join(' ') : '\t'
 
-    let line = document.lineAt(selection.active.line)
+    const line = document.lineAt(selection.active.line)
     let indentLength = line.firstNonWhitespaceCharacterIndex
     if (/\{$/.test(line.text)) {
         indentLength++


### PR DESCRIPTION
Hi,
+ By default, It's a good practice to define variables as **const**, unless you are planning to change the variable.
+ In consoleWrapper.ts: if a function is one line, arrow function will return the expression. so the word **return** is redundant. 
